### PR TITLE
Add Research Publications section to portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,42 @@
 
 							</div>
 													</div>
+						<div class="row">
+							<div class="col-12">
+
+								<!-- Research Publications -->
+									<section>
+										<header class="major">
+											<h2>Research Publications</h2>
+										</header>
+										<div class="row">
+											<div class="col-12">
+												<ul class="divided">
+													<li>
+														<h3><a href="https://www.jstage.jst.go.jp/article/pjsai/JSAI2022/0/JSAI2022_4Yin223/_article/-char/ja/">ニューラルネットワークの知識蒸留による方程式抽出 / Equation Extraction through Knowledge Distillation of Neural Networks</a></h3>
+														<p><strong>岡田 領</strong>, 横山 諒伍, 松尾 豊</p>
+														<p>人工知能学会全国大会論文集 JSAI2022, 2022年</p>
+														<p>深層学習モデルの知識蒸留を用いた方程式抽出に関する研究</p>
+													</li>
+													<li>
+														<h3><a href="https://www.jstage.jst.go.jp/article/pjsai/JSAI2023/0/JSAI2023_1G4OS21a02/_article/-char/en">Construction and Validation of Action-Conditioned VideoGPT</a></h3>
+														<p>Koudai Tabata, Junnosuke Kamohara, Ryosuke Unno, Makoto Sato, Taiju Watanabe, Taiga Kume, Masahiro Negishi, <strong>Ryo Okada</strong>, Yusuke Iwasawa, Yutaka Matsuo</p>
+														<p>37th Annual Conference of JSAI, 2023</p>
+														<p>World models using action-conditioned video prediction based on VideoGPT</p>
+													</li>
+														<li>
+															<h3><a href="https://www.jstage.jst.go.jp/article/pjsai/JSAI2022/0/JSAI2022_3L4GS803/_article/-char/en">Imitation Learning with Mid-Level Representations for Object Rearrangement</a></h3>
+															<p>Makoto Sato, Ryosuke Unno, Hiroki Furuta, Tatsuya Matsushima, <strong>Ryo Okada</strong>, Pavel Savkin, Genki Sano, Yutaka Matsuo</p>
+															<p>36th Annual Conference of JSAI, 2022</p>
+															<p>Using depth maps as mid-level representations to improve robotic object manipulation through imitation learning</p>
+														</li>
+												</ul>
+											</div>
+										</div>
+									</section>
+
+							</div>
+													</div>
 					</div>
 				</section>
 


### PR DESCRIPTION
## Summary
- Add new Research Publications section to showcase academic contributions
- Include three JSAI conference papers (2022-2023) with full citation details
- Enhance portfolio to demonstrate research experience in AI/ML

## Test plan
- [x] Verify HTML structure is valid and maintains existing layout
- [x] Check that all publication links are working
- [x] Ensure responsive design works on mobile/tablet
- [ ] Test in different browsers

🤖 Generated with [Claude Code](https://claude.ai/code)