### PR TITLE
Rebuild portfolio with Astro (YAML data-driven) + fix Gallery images

### DIFF
--- a/src/components/Gallery.astro
+++ b/src/components/Gallery.astro
@@ -8,14 +8,6 @@ interface Props {
 const { projects } = Astro.props;
 const artProjects = projects.filter(p => p.type === 'art');
 const base = import.meta.env.BASE_URL;
-
-const imageMap: Record<string, string> = {
-  'Audio Reactive StyleGAN': 'stylegan.gif',
-  'Latent Space Interpolation': 'star.gif',
-  'Lyric Driven Music Video': 'OneMoreTime.gif',
-  'Prompt Driven Pixel Art': 'darkyoda.png',
-  'Genetic Algorithm (Mona Lisa)': 'monalisa.gif',
-};
 ---
 
 <section id="gallery" class="section">
@@ -24,9 +16,9 @@ const imageMap: Record<string, string> = {
     <div class="gallery-grid">
       {artProjects.map(p => (
         <div class="gallery-item glass">
-          {imageMap[p.name] && (
+          {p.image && (
             <div class="gallery-image">
-              <img src={`${base}images/${imageMap[p.name]}`} alt={p.name} loading="lazy" />
+              <img src={`${base}/images/${p.image}`} alt={p.name} loading="lazy" />
             </div>
           )}
           <div class="gallery-info">

--- a/src/utils/loadData.ts
+++ b/src/utils/loadData.ts
@@ -17,6 +17,7 @@ export interface Project {
   highlight?: boolean;
   role?: string;
   type?: string;
+  image?: string;
 }
 
 export interface CareerEntry {


### PR DESCRIPTION
## Summary
- Rebuild the portfolio site with Astro v6, sourcing content from YAML files in the LIFE repo (data-driven architecture).
- Fix the Gallery: images 404'd because `${base}images/` rendered as `/portfolioimages/...` (the `base` config has no trailing slash). Added the missing slash.
- Make Gallery images data-driven: thumbnail filenames now come from an `image` field on each art project in `projects.yaml`, replacing a hardcoded name→file map in the component.

## Notes
- Production deploy (GitHub Pages) triggers on push to `main` and fetches YAML from the LIFE repo via the GitHub API. The matching `image:` fields were already pushed to `LIFE` `main`, so the Gallery thumbnails will resolve after this merges.

## Test plan
- `npm run build` passes.
- Built `dist/index.html` renders 5 gallery items with correct `/portfolio/images/*` paths.

https://claude.ai/code/session_015qbYRkGTHAHwpCmUERNigE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Gallery images are now sourced from project data; projects can specify their image filenames directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->