### PR TITLE
Add Google Analytics 4 (production-only, gated by PUBLIC_GA_ID)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Google Analytics 4 measurement id (format: G-XXXXXXXXXX).
+# Copy this file to `.env` for local testing. `.env` is gitignored.
+# In CI it is provided via the GitHub repository variable `PUBLIC_GA_ID`.
+# Note: GA only loads in production builds (`npm run build`), not in `npm run dev`.
+PUBLIC_GA_ID=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
         run: npm ci
 
       - name: Build
+        env:
+          PUBLIC_GA_ID: ${{ vars.PUBLIC_GA_ID }}
         run: npm run build
 
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 # Environment
 .env
 .env.*
+!.env.example
 
 # OS
 .DS_Store

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,6 +4,12 @@ interface Props {
 }
 const { title = "Ryo Okada - Portfolio" } = Astro.props;
 const base = import.meta.env.BASE_URL;
+
+// Google Analytics 4: load only in production builds and only when an id is
+// configured. The PUBLIC_ prefix exposes the var to the client; a G-XXXX id
+// is not a secret. Unconfigured builds simply omit the tag (fail-safe).
+const GA_ID = import.meta.env.PUBLIC_GA_ID;
+const enableAnalytics = import.meta.env.PROD && Boolean(GA_ID);
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -15,6 +21,17 @@ const base = import.meta.env.BASE_URL;
   <link rel="icon" type="image/svg+xml" href={`${base}/favicon.svg`} />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.min.js"></script>
+  {enableAnalytics && (
+    <Fragment>
+      <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`} is:inline></script>
+      <script is:inline define:vars={{ GA_ID }}>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){ dataLayer.push(arguments); }
+        gtag('js', new Date());
+        gtag('config', GA_ID);
+      </script>
+    </Fragment>
+  )}
 </head>
 <body>
   <canvas id="cosmic-canvas"></canvas>


### PR DESCRIPTION
## What

Adds **Google Analytics 4** to the site, loaded **only in production builds** and **only when a measurement id is configured**.

- `BaseLayout.astro`: injects gtag.js when `import.meta.env.PROD && PUBLIC_GA_ID` is set, via `define:vars` (inline, injection-safe)
- `deploy.yml`: passes the `PUBLIC_GA_ID` repository **variable** into the build step
- `.gitignore`: adds `!.env.example` — the existing `.env.*` rule was swallowing the example file
- `.env.example`: documents the variable for local production builds

## Why gated

`npm run dev` traffic stays out of analytics, and the site deploys fine even when unconfigured (the tag is simply omitted — fail-safe).

## Verified

- Build **without** id → no `googletagmanager` in `dist/index.html`
- Build **with** id → `gtag/js?id=...` present in `dist/index.html`

## Activation (post-merge, by maintainer)

1. Create a GA4 property + Web data stream → copy `G-XXXXXXXXXX`
2. Add repo variable `PUBLIC_GA_ID` (Settings → Secrets and variables → Actions → Variables)
3. Re-run the deploy

https://claude.ai/code/session_01ArvMoMZ2JqMhMwqy7pZZDw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Google Analytics 4 integration with configurable measurement ID.
  * Analytics tracking is automatically disabled in development builds.

* **Chores**
  * Added environment configuration template for GA ID setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->