### PR TITLE
Load p5.js via is:inline (classic global script, hardening)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -20,7 +20,7 @@ const enableAnalytics = import.meta.env.PROD && Boolean(GA_ID);
   <title>{title}</title>
   <link rel="icon" type="image/svg+xml" href={`${base}/favicon.svg`} />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.min.js"></script>
+  <script is:inline src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.min.js"></script>
   {enableAnalytics && (
     <Fragment>
       <script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`} is:inline></script>


### PR DESCRIPTION
## What

Adds `is:inline` to the p5.js CDN `<script>` in `BaseLayout.astro`.

## Why

Without `is:inline`, Astro processes the tag and rewrites it to
`import "https://.../p5.min.js"` inside a deferred module. The cosmic
network animation (`CosmicNetwork.astro`) relies on the **global** `p5`
(`new p5(...)`).

**This is hardening, not a bug fix** — verified in-browser that production
currently works (p5's UMD still sets `window.p5`, and the head module runs
before the cosmic module). But that relies on import side-effect globals +
execution ordering. `is:inline` emits a plain classic `<script src>` so p5
loads synchronously as intended, removing the latent fragility.

## Verification (real browser, agent-browser)

| | `window.p5` | canvas | p5 script | console errors |
|---|---|---|---|---|
| Production (current, `import`) | function | 1280×720 | module | none |
| This PR (`is:inline`) | function | 1280×720 | **classic** | none |

Both render identically; this PR additionally restores the classic
(non-module) p5 script tag.

https://claude.ai/code/session_01ArvMoMZ2JqMhMwqy7pZZDw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized script loading configuration for improved performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->