### PR TITLE
Fix invisible cosmic animation (mount p5 canvas in a div)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -34,7 +34,7 @@ const enableAnalytics = import.meta.env.PROD && Boolean(GA_ID);
   )}
 </head>
 <body>
-  <canvas id="cosmic-canvas"></canvas>
+  <div id="cosmic-canvas"></div>
   <div id="page-wrapper">
     <slot />
   </div>


### PR DESCRIPTION
## Bug

The cosmic particle animation was **invisible** on the live site.

## Root cause

`#cosmic-canvas` in `BaseLayout.astro` was a `<canvas>` element. `CosmicNetwork.astro`
mounts the p5 canvas into it with `canvas.parent('cosmic-canvas')`, nesting a
`<canvas>` inside a `<canvas>`. **Child elements of a `<canvas>` are fallback
content** — rendered only when canvas is unsupported — so the p5 canvas was never
laid out (`getBoundingClientRect()` = 0×0), even though p5 ran fine and the canvas
had a 1280×720 backing store. This is why dimension checks passed but nothing showed.

Pre-existing since the Astro rebuild; unrelated to the GA4 / p5 `is:inline` changes.

## Fix

Change the mount target from `<canvas id="cosmic-canvas">` to `<div id="cosmic-canvas">`.
The `#cosmic-canvas` CSS is an id selector, so it applies unchanged.

## Verification (real browser, agent-browser)

| | mount tag | p5 canvas rect | painted pixels |
|---|---|---|---|
| Before (prod) | CANVAS | **0×0** | n/a (not laid out) |
| After (this PR) | DIV | **1280×720** | **yes** |

Screenshot confirms the particle network renders (was a blank dark background).

https://claude.ai/code/session_01ArvMoMZ2JqMhMwqy7pZZDw